### PR TITLE
Updated wp_editor to avoid error in WordPress 3.9

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -242,7 +242,7 @@ function be_register_genesis_404_settings() {
 	
 	
 		echo '<p>' . __( 'Page Content', 'genesis-404' ) . '</p>';
-		wp_editor( genesis_get_option( 'content', 'genesis-404' ), $this->get_field_id( 'content' ) ); 
+		wp_editor( genesis_get_option( 'content', 'genesis-404' ), 'content', array( 'textarea_name' => $this->get_field_id( 'content' ), ) );  
 		}
 	
 	


### PR DESCRIPTION
The editor id is not the correct place for the field id, but the 'textarea_name' argument in the settings parameter.
